### PR TITLE
Add translated README files

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,47 @@
+# NanoFast Results Compiler
+
+🌐 Leer en: [English](README.md) | [Português (Brasil)](README.pt-br.md) | [Português (Portugal)](README.pt-pt.md) | [Español](README.es.md) | [Français](README.fr.md)
+
+## Para qué sirve el Script
+El Compilador de Resultados NanoFast es una herramienta de automatización en Python diseñada para agilizar el procesamiento y la presentación de los resultados de las pruebas Nanofast. Compila automáticamente los resultados individuales desde un lector o guardados localmente en una plantilla maestra de Excel estructurada y de fácil lectura para su análisis posterior.
+
+## Cómo funciona
+1. **Extracción de Datos:** El script escanea los datos dentro del directorio `Raw Data` o desde el dispositivo lector en busca de carpetas de resultados. Para cada carpeta, abre el archivo CSV de destino y su archivo `result.json` complementario.
+2. **Extracción de Metadatos:** Extrae metadatos específicos del JSON (incluyendo el ID de la Muestra, el Identificador del Casete, el Código de Lote, los detalles del Protocolo, la Fecha/Hora y el Resultado Final) y los superpone sobre los datos sin procesar del CSV.
+3. **Inyección en la Plantilla:** El script crea una hoja de cálculo de Excel y pega los datos compilados en la hoja `Raw Data`, asignando una columna por cada resultado de prueba.
+4. **Agrupación y Nomenclatura:** Para evitar desbordamientos en la plantilla, el script procesa los resultados en lotes de 40. Genera dinámicamente archivos de salida nombrados con la fecha actual, la hora y el número de lote (por ejemplo, `Compiled NanoFast Results - 07 Jul 26 - 15.43 - Part 1.xlsx`).
+5. **Limpieza:** Tras completarse con éxito, si el script se ejecuta localmente, purga automáticamente la carpeta `Raw Data` con los datos copiados para asegurar que quede vacía y lista para la siguiente ejecución.
+
+## Cómo Instalar
+### Requisitos previos
+* Instale Python *directamente desde la Microsoft Store*. El script ha sido probado con `Python 3.13`.
+* Descargue la última versión del repositorio en GitHub, utilizando la sección de lanzamientos (releases) en la barra lateral.
+* En la sección de recursos (assets) de la página de lanzamientos, descargue el archivo .zip.
+### Instalación
+* Extraiga el archivo .zip directamente en su disco C:. No se recomiendan instalaciones en otros lugares, ya que pueden provocar errores en la ruta de los archivos.
+
+### Primera ejecución
+* En el primer uso, el script descarga automáticamente las dependencias necesarias. Por favor, permita que este proceso finalice.
+* Después de la instalación de los paquetes, se le pedirá que seleccione su idioma preferido.
+* Las ejecuciones posteriores omitirán esta fase de configuración y procederán directamente al compilador.
+
+## Cómo Usar
+### Pasos de Ejecución
+1. Si procesa datos desde un dispositivo, conecte el lector Nanofast al PC mediante un cable USB-C, encienda el lector y ponga el dispositivo en 'Modo de Almacenamiento Masivo' (Mass Storage Mode) usando el Menú del lector. Si utiliza datos locales, copie todas las carpetas de resultados de pruebas individuales (cada una con un CSV y un `result.json`) en la carpeta `Raw Data`.
+2. Ejecute el archivo `Solus NanoFast Compliler.bat` haciendo doble clic.
+3. Seleccione la ubicación adecuada para el procesamiento de datos.
+    * Presione 1 para Automático. Esto obtiene los resultados automáticamente desde el dispositivo.
+    * Presione 2 para Manual. Para esta opción, copie manualmente los resultados en la carpeta llamada `Raw Data`.  
+4. Seleccione el rango de fechas para el procesamiento de datos utilizando las flechas hacia arriba y hacia abajo y seleccionando con Enter.
+5. El script mostrará una advertencia en la terminal indicando que la carpeta `Raw Data` será eliminada después del procesamiento. Escriba `Y` y/o presione **Enter** para continuar. Los datos almacenados en un Lector no se pueden eliminar; esto solo importa si ha transferido archivos manualmente.
+6. La terminal mostrará el progreso a medida que agrupa y exporta los datos.
+7. Una vez completado, recupere sus archivos `Compiled NanoFast Results` recién generados desde el directorio principal. La carpeta `Raw Data` ahora estará vacía.
+
+## Problemas Conocidos
+1. Durante la primera ejecución, el script instala pandas con éxito, pero falla al inicializarse en la misma sesión. Como solución temporal, reiniciar el script resolverá el problema. Este es un problema conocido programado para ser resuelto en un próximo parche.
+
+## Traducción
+La traducción ha sido realizada por Google y no por un hablante nativo. Por favor, envíe sus comentarios sobre la traducción en GitHub. Pedimos disculpas por cualquier error.
+
+---
+Script creado por Steve Carter en 2026.

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,0 +1,47 @@
+# NanoFast Results Compiler
+
+🌐 Lisez ceci en : [English](README.md) | [Português (Brasil)](README.pt-br.md) | [Português (Portugal)](README.pt-pt.md) | [Español](README.es.md) | [Français](README.fr.md)
+
+## À quoi sert le Script
+Le Compilateur de Résultats NanoFast est un outil d'automatisation Python conçu pour simplifier le traitement et la présentation des résultats de tests Nanofast. Il compile automatiquement les résultats individuels depuis un lecteur ou enregistrés localement vers un modèle Excel maître structuré et facilement lisible pour une analyse ultérieure.
+
+## Comment ça marche
+1. **Récupération des Données :** Le script analyse les données dans le répertoire `Raw Data` ou depuis le lecteur pour trouver des dossiers de résultats. Pour chaque dossier, il ouvre le fichier CSV cible et son fichier `result.json` associé.
+2. **Extraction des Métadonnées :** Il extrait des métadonnées spécifiques du JSON (y compris l'ID de l'Échantillon, l'Identifiant de la Cassette, le Code de Lot, les détails du Protocole, la Date/l'Heure et le Résultat Final) et les superpose aux données brutes du CSV.
+3. **Injection dans le Modèle :** Le script crée un fichier Excel et colle les données compilées dans la feuille `Raw Data`, en attribuant une colonne par résultat de test.
+4. **Traitement par Lots et Nommage :** Pour éviter de surcharger le modèle, le script traite les résultats par lots de 40. Il génère dynamiquement des fichiers de sortie nommés avec la date actuelle, l'heure et le numéro de lot (par exemple, `Compiled NanoFast Results - 07 Jul 26 - 15.43 - Part 1.xlsx`).
+5. **Nettoyage :** Une fois l'opération réussie, si le script est exécuté localement, il purge automatiquement le dossier `Raw Data` contenant les données copiées pour s'assurer qu'il soit vide et prêt pour la prochaine exécution.
+
+## Comment l'Installer
+### Prérequis
+* Installez Python *directement depuis le Microsoft Store*. Le script a été testé avec `Python 3.13`.
+* Téléchargez la dernière version depuis le dépôt GitHub, en utilisant la section des versions (releases) dans la barre latérale.
+* Dans la section des ressources (assets) de la page de la version, téléchargez le fichier .zip.
+### Installation
+* Extrayez le .zip directement dans votre disque C:. Les installations à d'autres emplacements ne sont pas recommandées et peuvent entraîner des erreurs de chemin d'accès.
+
+### Première exécution
+* Lors de la première utilisation, le script télécharge automatiquement les dépendances requises. Veuillez laisser ce processus se terminer.
+* Après l'installation des paquets, il vous sera demandé de sélectionner votre langue préférée.
+* Les exécutions ultérieures contourneront cette phase de configuration et passeront directement au compilateur.
+
+## Comment l'Utiliser
+### Étapes d'Exécution
+1. Si vous traitez des données depuis un appareil, connectez le lecteur Nanofast au PC à l'aide d'un câble USB-C, allumez le lecteur et mettez l'appareil en 'Mode de Stockage de Masse' (Mass Storage Mode) via le Menu du lecteur. Si vous utilisez des données locales, copiez tous les dossiers de résultats de tests individuels (chacun contenant un CSV et un `result.json`) dans le dossier `Raw Data`.
+2. Exécutez le fichier `Solus NanoFast Compliler.bat` en double-cliquant dessus.
+3. Sélectionnez l'emplacement approprié pour le traitement des données.
+    * Appuyez sur 1 pour Automatique. Cela récupère automatiquement les résultats depuis l'appareil.
+    * Appuyez sur 2 pour Manuel. Pour cette option, copiez manuellement les résultats dans le dossier nommé `Raw Data`.  
+4. Sélectionnez la plage de dates pour le traitement des données, en utilisant les flèches haut et bas et en validant avec Entrée.
+5. Le script affichera un avertissement dans le terminal vous informant que le dossier `Raw Data` sera supprimé après le traitement. Tapez `Y` et/ou appuyez sur **Entrée** pour continuer. Les données stockées sur un Lecteur ne peuvent pas être supprimées ; cela ne compte que si vous avez transféré des fichiers manuellement.
+6. Le terminal affichera la progression au fur et à mesure qu'il divise et exporte les données.
+7. Une fois terminé, récupérez vos fichiers `Compiled NanoFast Results` nouvellement générés dans le répertoire principal. Le dossier `Raw Data` sera désormais vide.
+
+## Problèmes Connus
+1. Lors du premier lancement, le script installe pandas avec succès mais ne parvient pas à s'initialiser dans la même session. Comme solution de contournement temporaire, le redémarrage du script résoudra le problème. Il s'agit d'un problème connu qui devrait être résolu dans un prochain correctif.
+
+## Traduction
+La traduction a été réalisée par Google et non par un locuteur natif. Veuillez fournir vos retours sur la traduction sur GitHub. Nous nous excusons pour toute erreur.
+
+---
+Script créé par Steve Carter en 2026.

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -1,0 +1,47 @@
+# NanoFast Results Compiler
+
+🌐 Leia em: [English](README.md) | [Português (Brasil)](README.pt-br.md) | [Português (Portugal)](README.pt-pt.md) | [Español](README.es.md) | [Français](README.fr.md)
+
+## Para que serve o Script
+O Compilador de Resultados NanoFast é uma ferramenta de automação em Python desenvolvida para agilizar o processamento e a apresentação dos resultados de testes Nanofast. Ele compila automaticamente resultados individuais armazenados em um leitor ou salvos localmente em um modelo mestre do Excel estruturado e de fácil leitura para análise posterior.
+
+## Como funciona
+1. **Coleta de Dados:** O script verifica os dados no diretório `Raw Data` ou no dispositivo leitor em busca de pastas de resultados. Para cada pasta, ele abre o arquivo CSV de destino e seu arquivo `result.json` correspondente.
+2. **Extração de Metadados:** Ele extrai metadados específicos do JSON (incluindo ID da Amostra, Identificador do Cassete, Código do Lote, detalhes do Protocolo, Data/Hora e Resultado Final) e os empilha sobre os dados brutos do CSV.
+3. **Injeção de Modelo:** O script cria uma planilha Excel e cola os dados compilados na aba `Raw Data`, atribuindo uma coluna por resultado de teste.
+4. **Lotes e Nomenclatura:** Para evitar o transbordamento do modelo, o script processa os resultados em lotes de 40. Ele gera dinamicamente arquivos de saída nomeados com a data atual, hora e número do lote (por exemplo, `Compiled NanoFast Results - 07 Jul 26 - 15.43 - Part 1.xlsx`).
+5. **Limpeza:** Após a conclusão bem-sucedida, se o script for executado localmente e os dados copiados, ele limpa automaticamente a pasta `Raw Data` para garantir que ela fique vazia e pronta para a próxima execução.
+
+## Como Instalar
+### Pré-requisitos
+* Instale o Python *diretamente da Microsoft Store*. O script foi testado com `Python 3.13`.
+* Baixe a versão mais recente do repositório no GitHub, usando a seção de lançamentos (releases) na barra lateral.
+* Na seção de ativos (assets) da página de lançamentos, baixe o arquivo .zip.
+### Instalação
+* Extraia o .zip diretamente em sua unidade C:. Instalações em outros locais não são recomendadas e podem resultar em erros de caminho de arquivo.
+
+### Primeira execução
+* No primeiro uso, o script baixa automaticamente as dependências necessárias. Por favor, permita que este processo seja concluído.
+* Após a instalação dos pacotes, você será solicitado a selecionar o idioma de sua preferência.
+* As execuções subsequentes ignorarão esta fase de configuração e prosseguirão diretamente para o compilador.
+
+## Como Usar
+### Passos de Execução
+1. Se for processar dados de um dispositivo, conecte o leitor Nanofast ao PC usando um cabo USB-C, ligue o leitor e coloque o dispositivo no 'Modo de Armazenamento em Massa' (Mass Storage Mode) usando o Menu no leitor. Se for usar dados locais, copie todas as pastas de resultados de testes individuais (cada uma contendo um CSV e um `result.json`) para a pasta `Raw Data`.
+2. Execute o arquivo `Solus NanoFast Compliler.bat` clicando duas vezes.
+3. Selecione o local apropriado para o processamento de dados.
+    * Pressione 1 para Automático. Isso obtém os resultados automaticamente do dispositivo.
+    * Pressione 2 para Manual. Para esta opção, copie os resultados manualmente para a pasta chamada `Raw Data`.  
+4. Selecione o intervalo de datas para o processamento de dados, usando as setas para cima e para baixo e confirmando com Enter.
+5. O script exibirá um aviso no terminal informando que a pasta `Raw Data` será excluída após o processamento. Digite `Y` e/ou pressione **Enter** para continuar. Os dados armazenados em um Leitor não podem ser excluídos; isso só importa se você tiver transferido arquivos manualmente.
+6. O terminal exibirá o progresso à medida que divide em lotes e exporta os dados.
+7. Quando concluído, recupere seus arquivos `Compiled NanoFast Results` recém-gerados no diretório principal. A pasta `Raw Data` agora estará vazia.
+
+## Problemas Conhecidos
+1. Durante a execução inicial, o script instala o pandas com sucesso, mas falha ao inicializar na mesma sessão. Como solução temporária, reiniciar o script resolverá o problema. Este é um problema conhecido programado para ser resolvido em uma próxima atualização.
+
+## Tradução
+A tradução foi realizada pelo Google e não por um falante nativo. Por favor, forneça feedback sobre a tradução no GitHub. Pedimos desculpas por quaisquer erros.
+
+---
+Script criado por Steve Carter em 2026.

--- a/README.pt-pt.md
+++ b/README.pt-pt.md
@@ -1,0 +1,47 @@
+# NanoFast Results Compiler
+
+🌐 Leia em: [English](README.md) | [Português (Brasil)](README.pt-br.md) | [Português (Portugal)](README.pt-pt.md) | [Español](README.es.md) | [Français](README.fr.md)
+
+## Para que serve o Script
+O Compilador de Resultados NanoFast é uma ferramenta de automação em Python concebida para agilizar o processamento e a apresentação dos resultados de testes Nanofast. Este compila automaticamente resultados individuais num leitor ou guardados localmente para um modelo principal do Excel estruturado e de fácil leitura para análise posterior.
+
+## Como funciona
+1. **Recolha de Dados:** O script verifica os dados no diretório `Raw Data` ou no dispositivo leitor à procura de pastas de resultados. Para cada pasta, abre o ficheiro CSV de destino e o respetivo ficheiro `result.json`.
+2. **Extração de Metadados:** Extrai metadados específicos do JSON (incluindo ID da Amostra, Identificador da Cassete, Código do Lote, detalhes do Protocolo, Data/Hora e Resultado Final) e junta-os aos dados brutos do CSV.
+3. **Injeção de Modelo:** O script cria uma folha de cálculo Excel e cola os dados compilados na folha `Raw Data`, atribuindo uma coluna por cada resultado de teste.
+4. **Lotes e Nomenclatura:** Para evitar o limite de capacidade do modelo, o script processa os resultados em lotes de 40. Gera dinamicamente ficheiros de saída nomeados com a data atual, hora e número do lote (por exemplo, `Compiled NanoFast Results - 07 Jul 26 - 15.43 - Part 1.xlsx`).
+5. **Limpeza:** Após a conclusão com sucesso, se o script for executado localmente, os dados copiados são eliminados automaticamente da pasta `Raw Data` para garantir que esta fica vazia e pronta para a próxima execução.
+
+## Como Instalar
+### Pré-requisitos
+* Instale o Python *diretamente a partir da Microsoft Store*. O script foi testado com `Python 3.13`.
+* Descarregue o lançamento mais recente do repositório no GitHub, utilizando a secção de lançamentos (releases) na barra lateral.
+* Na secção de ativos (assets) da página de lançamentos, descarregue o ficheiro .zip.
+### Instalação
+* Extraia o .zip diretamente para a sua unidade C:. Instalações noutros locais não são recomendadas e podem resultar em erros no caminho dos ficheiros.
+
+### Primeira execução
+* Na primeira utilização, o script descarrega automaticamente as dependências necessárias. Por favor, permita que este processo seja concluído.
+* Após a instalação dos pacotes, ser-lhe-á pedido que selecione o seu idioma preferido.
+* As execuções subsequentes ignorarão esta fase de configuração e prosseguirão diretamente para o compilador.
+
+## Como Usar
+### Passos de Execução
+1. Se estiver a processar dados de um dispositivo, ligue o leitor Nanofast ao PC utilizando um cabo USB-C, ligue o leitor e coloque o dispositivo em 'Modo de Armazenamento de Massa' (Mass Storage Mode) utilizando o Menu no leitor. Se estiver a utilizar dados locais, copie todas as pastas de resultados de testes individuais (cada uma contendo um CSV e um `result.json`) para a pasta `Raw Data`.
+2. Execute o ficheiro `Solus NanoFast Compliler.bat` com um duplo clique.
+3. Selecione o local apropriado para o processamento de dados.
+    * Pressione 1 para Automático. Isto obtém os resultados automaticamente do dispositivo.
+    * Pressione 2 para Manual. Para esta opção, copie manualmente os resultados para a pasta chamada `Raw Data`.  
+4. Selecione o intervalo de datas para o processamento de dados, utilizando as setas para cima e para baixo e selecionando com Enter.
+5. O script irá mostrar um aviso no terminal a informar que a pasta `Raw Data` será eliminada após o processamento. Escreva `Y` e/ou pressione **Enter** para continuar. Os dados armazenados num Leitor não podem ser eliminados; isto só tem impacto se tiver transferido ficheiros manualmente.
+6. O terminal irá mostrar o progresso à medida que divide em lotes e exporta os dados.
+7. Assim que estiver concluído, recupere os seus ficheiros `Compiled NanoFast Results` recém-gerados no diretório principal. A pasta `Raw Data` estará agora vazia.
+
+## Problemas Conhecidos
+1. No primeiro arranque, o script instala com sucesso o pandas, mas falha ao inicializar na mesma sessão. Como solução temporária, reiniciar o script irá resolver o problema. Este é um problema conhecido que está agendado para resolução numa próxima atualização.
+
+## Tradução
+A tradução foi realizada pelo Google e não por um falante nativo. Por favor, forneça o seu feedback sobre a tradução no GitHub. Pedimos desculpa por quaisquer erros.
+
+---
+Script criado por Steve Carter em 2026.

--- a/__lib__/lang.json
+++ b/__lib__/lang.json
@@ -17,7 +17,7 @@
     "no_excel": "No Excel files found in Raw Data. Please ensure the files are present and try again.",
     "complete": "Process complete. Script closing.",
     "script_stop": "Stopping Script.",
-    "translation_notice": "Translations by Google. Please feedback translation on GitHub. Apologies for any errors."
+    "translation_notice": ""
   },
   "PT-BR": {
   "package_not_found": "não encontrado. Instalando...",


### PR DESCRIPTION
Adds Spanish, French, and Portuguese (Brazil and Portugal) README translations to support multilingual documentation. Remove the translation notice for English lang.json.