### PR TITLE
Add uninstall script and reorganize imports

### DIFF
--- a/__lib__/NanoFast.py
+++ b/__lib__/NanoFast.py
@@ -3,6 +3,12 @@
 
 import sys
 import subprocess
+import os
+import shutil
+import json
+import glob
+import msvcrt
+from datetime import datetime
 
 
 def install_dependencies():
@@ -24,14 +30,7 @@ def install_dependencies():
 
 install_dependencies()
 
-import os  # noqa: E402
-import shutil  # noqa: E402
-import json  # noqa: E402
-import glob  # noqa: E402
 
-# import urllib.request  # noqa: E402 Not currently used, but retained for potential future use in GitHub update feature.
-import msvcrt  # noqa: E402
-from datetime import datetime  # noqa: E402
 import pandas as pd  # noqa: E402
 
 

--- a/uninstall.bat
+++ b/uninstall.bat
@@ -1,0 +1,13 @@
+@echo off
+echo Uninstalling NanoFast dependencies...
+python -m pip uninstall -y pandas openpyxl numpy python-dateutil six tzdata et_xmlfile
+
+echo Deleting NanoFast directory...
+:: Change directory to the parent folder to release the working directory lock
+cd /d "%~dp0.."
+
+:: Spawn an independent hidden command prompt that waits 2 seconds for this script to close, then deletes the folder
+start /min cmd /c "ping 127.0.0.1 -n 2 > nul & rd /s /q "%~dp0""
+
+:: Exit immediately to release the file lock
+exit


### PR DESCRIPTION
Move imports to the top of NanoFast.py following PEP 8 conventions and remove unnecessary noqa comments. Add uninstall.bat batch script to cleanly uninstall dependencies and remove the NanoFast directory.