### PR TITLE
Replace os.execv with subprocess.run

### DIFF
--- a/__lib__/NanoFast.py
+++ b/__lib__/NanoFast.py
@@ -25,7 +25,8 @@ def install_dependencies():
 
     if needs_restart:
         print("🔄 Initializing new packages... Restarting script.")
-        os.execv(sys.executable, [sys.executable] + sys.argv)
+        subprocess.run([sys.executable] + sys.argv)
+        sys.exit(0)
 
 
 install_dependencies()


### PR DESCRIPTION
Changed from using os.execv() to subprocess.run() for script restart after dependency installation. This approach provides better process management and allows the original process to properly exit with sys.exit(0) instead of being replaced directly. subprocess.run is the recommended modern approach for spawning processes.